### PR TITLE
Fix textAlign being set to flex-start rather than left

### DIFF
--- a/screens/ChefActionsScreen.js
+++ b/screens/ChefActionsScreen.js
@@ -251,7 +251,9 @@ class ChefActionsScreen extends Component {
   }
 
   render() {
-    return ( this.state.loading ? <ActivityIndicator size="large"/> :
+    return ( this.state.loading ? <View style={{flex: 1, justifyContent: 'center'}}>
+      <ActivityIndicator size="large"/>
+    </View> :
       <ScrollView>
         <TextInput
           onChangeText={(name)=>{this.setState({name})}}
@@ -334,20 +336,21 @@ class ChefActionsScreen extends Component {
         </View>       
         
         <View style={{backgroundColor: '#cfcfcf'}}>
-          <Text style={[styles.flex, 
-                        styles.textCenter, 
-                        styles.verticalMargins]}>
-            Your Menu
-          </Text>
           {this.props.currentChef ? 
-            <TouchableHighlight
-              underlayColor={'white'}
-              title="Edit Menu"
-              onPress={this.toggleState.bind(this, 'showDishesModal')}
-              style={[styles.test]}> 
-              <Text style={styles.textTest}>Edit Menu</Text>
-            </TouchableHighlight> : null
-          }
+            <View>
+              <Text style={[styles.flex, 
+                            styles.textCenter, 
+                            styles.verticalMargins]}>
+                Your Menu
+              </Text>
+              <TouchableHighlight
+                underlayColor={'white'}
+                title="Edit Menu"
+                onPress={this.toggleState.bind(this, 'showDishesModal')}
+                style={[styles.test]}> 
+                <Text style={styles.textTest}>Edit Menu</Text>
+              </TouchableHighlight>
+            </View> : null}
          </View>        
 
         <View style={styles.saveStyle}>

--- a/screens/ChefPageViewScreen.js
+++ b/screens/ChefPageViewScreen.js
@@ -210,7 +210,7 @@ class ChefPageViewScreen extends React.Component {
         flex: 0.5,
       },
       textStyling: {
-        textAlign: 'flex-start',
+        textAlign: 'left',
         fontSize: 20,
         fontWeight: '500',
         marginVertical: 1,
@@ -220,7 +220,7 @@ class ChefPageViewScreen extends React.Component {
 
       },
       textStylingAbout: {
-        textAlign: 'flex-start',
+        textAlign: 'left',
         fontSize: 14,
         fontWeight: '500',
         marginVertical: 1,


### PR DESCRIPTION
- Center loading spinner on chef actions screen
- Hide 'Your Menu' heading on chef actions when not yet registered